### PR TITLE
feat(presenter): Add line spacing controls

### DIFF
--- a/src/components/Presentation/Presentation.tsx
+++ b/src/components/Presentation/Presentation.tsx
@@ -23,9 +23,11 @@ export const Presentation = ({
   const {
     showArabic,
     arabicFontSize,
+    arabicLineHeight,
     showTranslation,
     backgroundColor,
     translationFontSize,
+    translationLineHeight,
     translationLanguage,
     arabicFontColor,
     translationFontColor,
@@ -74,6 +76,7 @@ export const Presentation = ({
                 className="text-center font-serif drop-shadow-md"
                 style={{
                   fontSize: arabicFontSize * textScale,
+                  lineHeight: arabicLineHeight,
                   color: arabicFontColor,
                   textShadow:
                     "1px 1px 2px rgba(0, 0, 0, 0.6), -1px -1px 1px rgba(255, 255, 255, 0.2)",
@@ -90,6 +93,7 @@ export const Presentation = ({
                 className="flex text-center drop-shadow-md"
                 style={{
                   fontSize: translationFontSize * textScale,
+                  lineHeight: translationLineHeight,
                   color: translationFontColor,
                   textShadow:
                     "1px 1px 2px rgba(0, 0, 0, 0.6), -1px -1px 1px rgba(255, 255, 255, 0.2)",

--- a/src/components/SettingsOptions/SettingsOptions.tsx
+++ b/src/components/SettingsOptions/SettingsOptions.tsx
@@ -13,6 +13,37 @@ interface SettingsOptionsProps {
   expandable?: boolean;
 }
 
+interface LineSpacingSliderProps {
+  id: string;
+  value: number;
+  onChange: (lineHeight: number) => void;
+}
+
+const LineSpacingSlider = ({ id, value, onChange }: LineSpacingSliderProps) => {
+  return (
+    <div className="flex items-center justify-between gap-6">
+      <label htmlFor={id} className="text-sm">
+        Line Spacing
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          id={id}
+          type="range"
+          min={0.8}
+          max={2}
+          step={0.05}
+          value={value}
+          onChange={(event) => onChange(parseFloat(event.target.value))}
+          className="w-24 accent-gray-700"
+        />
+        <span className="w-10 text-right text-xs text-gray-600">
+          {value.toFixed(2)}x
+        </span>
+      </div>
+    </div>
+  );
+};
+
 export const SettingsOptions = ({
   expandable = false,
 }: SettingsOptionsProps) => {
@@ -25,7 +56,9 @@ export const SettingsOptions = ({
     arabicFontColor,
     translationFontColor,
     translationFontSize,
+    translationLineHeight,
     arabicFontSize,
+    arabicLineHeight,
     arabicSource,
     translationSource,
     layout,
@@ -245,6 +278,13 @@ export const SettingsOptions = ({
               }
             />
           </div>
+          <LineSpacingSlider
+            id="arabic-line-spacing-slider"
+            value={arabicLineHeight}
+            onChange={(arabicLineHeight) =>
+              updateSettings({ arabicLineHeight })
+            }
+          />
           <div className="flex items-center justify-between gap-6">
             <p className="text-sm">Font Style</p>
             <Combobox
@@ -296,6 +336,13 @@ export const SettingsOptions = ({
               }
             />
           </div>
+          <LineSpacingSlider
+            id="translation-line-spacing-slider"
+            value={translationLineHeight}
+            onChange={(translationLineHeight) =>
+              updateSettings({ translationLineHeight })
+            }
+          />
           <div className="flex items-center justify-between gap-6">
             <p className="text-sm">Source</p>
             <Combobox

--- a/src/hooks/hooksProvider.tsx
+++ b/src/hooks/hooksProvider.tsx
@@ -14,11 +14,13 @@ export const DefaultSettings: SettingsType = {
   showArabic: true,
   arabicSource: "Simple Enhanced",
   arabicFontSize: 32,
+  arabicLineHeight: 1.2,
   arabicFontColor: "#ffffff",
   showTranslation: true,
   translationLanguage: "ENGLISH",
   translationSource: "Shakir",
   translationFontSize: 22,
+  translationLineHeight: 1.2,
   translationFontColor: "#ffffff",
   layout: "Third",
   mode: PresenterMode.Default,
@@ -102,8 +104,12 @@ export const HookProvider = ({ children }: { children: React.ReactNode }) => {
       | undefined;
 
     if (settingsFromStorage) {
-      devLogger("Local Storage: Get", JSON.parse(settingsFromStorage));
-      setSettings(JSON.parse(settingsFromStorage) as SettingsType);
+      const parsedSettings = JSON.parse(
+        settingsFromStorage
+      ) as Partial<SettingsType>;
+      const settingsWithDefaults = { ...DefaultSettings, ...parsedSettings };
+      devLogger("Local Storage: Get", settingsWithDefaults);
+      setSettings(settingsWithDefaults);
     }
   }, []);
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -12,11 +12,13 @@ export interface SettingsType {
   settingsAreaBackgroundColor: string;
   showArabic: boolean;
   arabicFontSize: number;
+  arabicLineHeight: number;
   arabicFontColor: string;
   arabicSource: string;
   showTranslation: boolean;
   translationLanguage: "ENGLISH" | "URDU" | "FRENCH";
   translationFontSize: number;
+  translationLineHeight: number;
   translationFontColor: string;
   translationSource: string;
   layout: LayoutOptions;
@@ -104,7 +106,7 @@ export const useSettings = () => {
       const templates = getTemplates();
       const template = templates.find((t) => t.id === templateId);
       if (template) {
-        updateSettings(template.settings);
+        updateSettings({ ...DefaultSettings, ...template.settings });
         devLogger("Local Storage: Load Template", template);
       }
     },


### PR DESCRIPTION
## Summary
- Adds independent line spacing sliders for Arabic and English text in presenter settings.
- Applies line-height settings through the shared Presentation renderer so all layouts inherit the behavior.
- Merges new defaults into existing saved settings/templates for backward compatibility.

## Validation
- yarn prettier --write src/hooks/useSettings.ts src/hooks/hooksProvider.tsx src/components/SettingsOptions/SettingsOptions.tsx src/components/Presentation/Presentation.tsx
- DATABASE_URL=<local> yarn lint
- DATABASE_URL=<local> yarn build
- git diff --check
- Local browser smoke test at /presenter with the personal env file
