### PR TITLE
fix(prisma): Add Netlify query engine target

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -2,7 +2,8 @@
 // learn more about it in the docs: https://pris.ly/d/prisma-schema
 
 generator client {
-    provider = "prisma-client-js"
+    provider      = "prisma-client-js"
+    binaryTargets = ["native", "rhel-openssl-3.0.x"]
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- Adds Prisma's `rhel-openssl-3.0.x` binary target for the Netlify serverless runtime.
- Keeps `native` so local and build-platform Prisma generation still works normally.

## Root cause
The deployed Netlify function runtime requires Prisma's RHEL OpenSSL 3 query engine, but the client generated during build only included the Debian OpenSSL 3 engine. The API failed before it could connect to Supabase.

## Validation
- DATABASE_URL=<local> yarn prisma validate
- yarn prisma generate
- verified `node_modules/.prisma/client/libquery_engine-rhel-openssl-3.0.x.so.node` exists after generation
- DATABASE_URL=<local> yarn build
- git diff --check
